### PR TITLE
Delete unnecessary flags

### DIFF
--- a/autoload/molder/extension/operations.vim
+++ b/autoload/molder/extension/operations.vim
@@ -60,7 +60,7 @@ function! molder#extension#operations#delete() abort
     endtry
   else
     try
-      if delete(l:path, 'f') == -1
+      if delete(l:path) == -1
         throw 'failed'
       endif
     catch


### PR DESCRIPTION
`<plug>(molder-operations-delete)` can delete a directory, but it fails to delete a file.
According to help, 'f' flag is needless to delete a file.

```
delete({fname} [, {flags}])                                     delete()
                Without {flags} or with {flags} empty: Deletes the file by the
                name {fname}.  This also works when {fname} is a symbolic link.
```