### PR TITLE
fix: helpで記述されているPlugと実装されているPlugの名前が違うのを修正しました。

### DIFF
--- a/doc/molder-operations.txt
+++ b/doc/molder-operations.txt
@@ -31,7 +31,7 @@ vim-plug: add below to .vimrc
 ==============================================================================
 KEYMAPPINGS                                      *molder-operations-keymappings*
 
-* "<leader>n": create directory. <plug>(molder-operations-mkdir)
+* "<leader>n": create directory. <plug>(molder-operations-newdir)
 * "<leader>d": delete. <plug>(molder-operations-delete)
 * "<leader>r": rename. <plug>(molder-operations-rename)
 * "<leader>!": edit command line for making command.


### PR DESCRIPTION
実際の実装では、新規ディレクトリ作成のPlugは  `<plug>(molder-operations-newdir)`になっていますが、
helpでは`<plug>(molder-operations-mkdir)`となっていたので修正しました。